### PR TITLE
format dates using i18next

### DIFF
--- a/__mocks__/react-i18next.js
+++ b/__mocks__/react-i18next.js
@@ -31,7 +31,12 @@ const renderNodes = reactNodes => {
 
 const useMock = [k => k, {}]
 useMock.t = k => k
-useMock.i18n = {}
+useMock.i18n = {
+  format: value => {
+    const date = new Date(value)
+    return `${date.getUTCMonth()} - ${date.getUTCFullYear()}`
+  }
+}
 
 module.exports = {
   // this mock makes sure any components using the translate HoC receive the t function as a prop

--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -3,7 +3,7 @@ import * as Permissions from 'expo-permissions'
 import { Notifications } from 'expo'
 
 import { App } from './app'
-import { render, routerStubProps, i18nStubProps, waitOnTick } from './test-utils'
+import { render, routerStubProps, waitOnTick } from './test-utils'
 import { Connection, Action, Institution, BalanceMonitor } from 'src/types'
 
 // We need to mock expo because jest can not spy on Notification methods: it fails with message.
@@ -22,7 +22,6 @@ const stubProps = {
   checkActions: jest.fn(),
   checkConnections: jest.fn(),
   setTransferAmount: jest.fn(),
-  ...i18nStubProps,
   ...routerStubProps
 }
 

--- a/src/components/molecules/action/index.tsx
+++ b/src/components/molecules/action/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { View, Text, StyleSheet, TouchableWithoutFeedback } from 'react-native'
-import { format } from 'date-fns'
 import { RouteComponentProps } from 'routing'
+import { useTranslation } from 'react-i18next'
 
 import Icon from 'components/atoms/icon'
 
@@ -14,6 +14,7 @@ type Props = RouteComponentProps & {
   any
 
 const Action: React.FC<Props> = ({ name, start, end, onPress }) => {
+  const { i18n } = useTranslation()
   return (
     <TouchableWithoutFeedback onPress={onPress}>
       <View style={styles.action}>
@@ -24,7 +25,7 @@ const Action: React.FC<Props> = ({ name, start, end, onPress }) => {
           </Text>
           {start && end && (
             <Text style={styles.date}>
-              {format(start, 'do MMM yyyy')} - {format(end, 'do MMM yyyy')}
+              {i18n.format(start, 'date-do')} - {i18n.format(end, 'date-do')}
             </Text>
           )}
         </View>

--- a/src/components/organisms/transaction/index.tsx
+++ b/src/components/organisms/transaction/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
-import { format, parseISO } from 'date-fns'
+import { parseISO } from 'date-fns'
 import { Animated, Image, View, Text, StyleSheet } from 'react-native'
+import { useTranslation } from 'react-i18next'
 
 import Icon from 'components/atoms/icon'
 import TransactionIcons from 'services/transaction-icons'
@@ -17,6 +18,7 @@ interface State {
 }
 
 const Transaction: React.FC<Props> = props => {
+  const { i18n } = useTranslation()
   const [state] = useState<State>({
     opacityAnimation: new Animated.Value(0)
   })
@@ -34,7 +36,7 @@ const Transaction: React.FC<Props> = props => {
   const { title, amount, currency, date, icon } = props
   const opacity = { opacity: state.opacityAnimation }
   const d = new Date(date)
-  const formattedDate = d.toString() === 'Invalid Date' ? date : format(parseISO(date), 'do MMM yyyy')
+  const formattedDate = d.toString() === 'Invalid Date' ? date : i18n.format(parseISO(date), 'date_do')
   let useIcon = <Icon name="ic-clothing" />
   if (icon) {
     useIcon = <Image source={TransactionIcons[icon]} style={{ width: 36, height: 36 }} />

--- a/src/components/views/actions/create.test.tsx
+++ b/src/components/views/actions/create.test.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
 
 import { CreateAction } from './create'
-import { render, fireEvent, i18nStubProps, routerStubProps } from 'test-utils'
+import { render, fireEvent, routerStubProps } from 'test-utils'
 
 const stubProps = {
-  ...i18nStubProps,
   ...routerStubProps,
   match: {
     params: { id: 'action-id' },

--- a/src/components/views/actions/index.test.tsx
+++ b/src/components/views/actions/index.test.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
 
 import { Actions } from './'
-import { render, fireEvent, routerStubProps, i18nStubProps } from 'test-utils'
+import { render, fireEvent, routerStubProps } from 'test-utils'
 
 const stubProps = {
-  ...i18nStubProps,
   ...routerStubProps,
   match: {
     params: { connection: 'connection-id' },

--- a/src/components/views/connect/index.test.tsx
+++ b/src/components/views/connect/index.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { Linking } from 'react-native'
 import { Connect } from './'
-import { render, fireEvent, i18nStubProps, routerStubProps, waitOnTick } from 'test-utils'
+import { render, fireEvent, routerStubProps, waitOnTick } from 'test-utils'
 import * as api from 'services/api'
 
 jest.mock('services/api')
@@ -13,7 +13,6 @@ beforeEach(() => {
 })
 
 const stubProps = {
-  ...i18nStubProps,
   ...routerStubProps,
   match: {
     params: { connection: 'connection-id' },

--- a/src/components/views/connect/notify.test.tsx
+++ b/src/components/views/connect/notify.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { Notify } from './notify'
-import { render, fireEvent, i18nStubProps, routerStubProps } from 'test-utils'
+import { render, fireEvent, routerStubProps } from 'test-utils'
 
 const connection = {
   access_token: '************',
@@ -17,7 +17,6 @@ const connection = {
 test('Notify view', async () => {
   const { getByText } = render(
     <Notify
-      {...i18nStubProps}
       {...routerStubProps}
       connections={[connection]}
       match={

--- a/src/components/views/messages/index.test.tsx
+++ b/src/components/views/messages/index.test.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
 
 import { Messages } from './'
-import { render, fireEvent, i18nStubProps } from 'test-utils'
+import { render, fireEvent } from 'test-utils'
 
 const stubProps = {
-  ...i18nStubProps,
   awaitingResponse: true,
   sendMessage: jest.fn()
 }

--- a/src/components/views/overview/index.test.tsx
+++ b/src/components/views/overview/index.test.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
 
 import Overview from './'
-import { render, i18nStubProps, routerStubProps } from 'test-utils'
+import { render, routerStubProps } from 'test-utils'
 
 const stubProps = {
-  ...i18nStubProps,
   ...routerStubProps,
   loadAccounts: jest.fn()
 }

--- a/src/components/views/transactions/index.test.tsx
+++ b/src/components/views/transactions/index.test.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
 
 import { Transactions } from './'
-import { render, i18nStubProps, routerStubProps } from 'test-utils'
+import { render, routerStubProps } from 'test-utils'
 
 const stubProps = {
-  ...i18nStubProps,
   ...routerStubProps
 }
 
@@ -38,6 +37,6 @@ test('Transactions view', () => {
 
   // ensure transaction values are displayed
   expect(getByText('Bank Transfer')).toBeTruthy()
-  expect(getByText('3rd Nov 2012')).toBeTruthy()
+  expect(getByText('10 - 2012')).toBeTruthy()
   expect(getByText('GBP')).toBeTruthy()
 })

--- a/src/components/views/transfer/between-accounts/index.test.tsx
+++ b/src/components/views/transfer/between-accounts/index.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { Linking } from 'react-native'
 import { Transfer } from './'
-import { render, fireEvent, i18nStubProps, routerStubProps, waitOnTick } from 'test-utils'
+import { render, fireEvent, routerStubProps, waitOnTick } from 'test-utils'
 import * as api from 'services/api'
 
 jest.mock('services/api')
@@ -13,7 +13,6 @@ beforeEach(() => {
 })
 
 const stubProps = {
-  ...i18nStubProps,
   ...routerStubProps,
   loadInstitutions: jest.fn(),
   setAmount: jest.fn(),

--- a/src/services/i18n/index.native.ts
+++ b/src/services/i18n/index.native.ts
@@ -25,8 +25,15 @@ i18n
     interpolation: {
       escapeValue: false,
       format: (value: Date | string, format: string): string => {
-        if (value instanceof Date && format) return formatDate(value, format)
-        else return value.toString()
+        if (value instanceof Date && format) {
+          switch (format) {
+            case 'date_do':
+              // we should pass locale to formatDate too
+              return formatDate(value, 'do MMM yyyy')
+            default:
+              return value.toISOString()
+          }
+        } else return value.toString()
       }
     }
   })

--- a/src/services/i18n/index.ts
+++ b/src/services/i18n/index.ts
@@ -16,8 +16,15 @@ i18n
     interpolation: {
       escapeValue: false,
       format: (value: Date | string, format: string): string => {
-        if (value instanceof Date && format) return formatDate(value, format)
-        else return value.toString()
+        if (value instanceof Date && format) {
+          switch (format) {
+            case 'date_do':
+              // we should pass locale to formatDate too
+              return formatDate(value, 'do MMM yyyy')
+            default:
+              return value.toString()
+          }
+        } else return value.toString()
       }
     }
   })

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -56,12 +56,6 @@ export const routerStubProps = {
   match: {} as any
 }
 
-export const i18nStubProps = {
-  t: (str: string) => str,
-  tReady: true,
-  i18n: {} as any
-}
-
 export async function waitOnTick() {
   await act(() => new Promise(resolve => setTimeout(resolve, 0)))
 }


### PR DESCRIPTION
**Contains:**

- moved format dates to i18next file so that we can have a central place for formatting any dates or basically anything that needs formatting 
- removed i18nstubs since they are not required cause we mock react-i18next 